### PR TITLE
Hide navigation panel on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,6 +244,18 @@
         .gallery a {
             text-decoration: none;
         }
+        @media (max-width: 600px) {
+            .profile-panel {
+                display: none;
+            }
+            header, section, footer {
+                margin-left: 5%;
+                margin-right: 5%;
+            }
+            .side_content {
+                width: 100%;
+            }
+        }
     </style>
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.css">
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>


### PR DESCRIPTION
## Summary
- Add a responsive CSS media query in `index.html` to hide the profile/navigation panel on narrow screens.
- Adjust page margins and side content width so main content expands when the panel is hidden.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ed66d9b8832e9f99e1d536f2deb8