### PR TITLE
Fix profile panel line and mobile width

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,6 +258,9 @@
             text-decoration: none;
         }
         @media (max-width: 600px) {
+            :root {
+                --panelWidth: min(80vw, 200px);
+            }
             .profile-panel {
                 display: none;
             }
@@ -776,7 +779,7 @@
         // ----------------------------------------------------------------------------------------- Profile Pannel and Navigation
         const profilePanel = document.querySelector('.profile-panel');
         const mainPic = document.querySelector('#overlayCanvas');
-        const linkImages = document.querySelectorAll('.image-links a');
+        const linkImages = profilePanel.querySelectorAll('.image-links a');
         const profileEdgeCanvas = document.getElementById('profileEdgeCanvas');
         const profileCtx = profileEdgeCanvas.getContext('2d');
 


### PR DESCRIPTION
## Summary
- prevent stray line to top-left by only connecting visible profile links
- expand mobile profile panel by overriding panel width on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f718f574832e8a1707b17f197579