### PR TITLE
Evenly space profile icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,16 +87,16 @@
 
         /* circular layout */
         .image-links a:nth-child(1) {
-            --angle: 50deg;
+            --angle: 45deg;
         }
         .image-links a:nth-child(2) {
-            --angle: 25deg;
+            --angle: 15deg;
         }
         .image-links a:nth-child(3) {
-            --angle: -25deg;
+            --angle: -15deg;
         }
         .image-links a:nth-child(4) {
-            --angle: -50deg;
+            --angle: -45deg;
         }
         /* .image-links a:nth-child(5) {
             --angle: -50deg;


### PR DESCRIPTION
## Summary
- Adjust profile icon angles so Google Scholar, ResearchGate, GitLab, and ORCID icons are evenly spaced beneath the profile photo.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fb5aed10832e91ddebb5e923c97f